### PR TITLE
Enable build with p4a

### DIFF
--- a/p4a-recipe/pyksolve/__init__.py
+++ b/p4a-recipe/pyksolve/__init__.py
@@ -1,0 +1,28 @@
+"""
+python-for-android recipe for pyksolve.
+"""
+
+from multiprocessing import cpu_count
+from os.path import join
+
+from pythonforandroid.recipe import CppCompiledComponentsPythonRecipe
+
+
+class PyksolveRecipe(CppCompiledComponentsPythonRecipe):
+    version = 'master'
+    url = 'https://github.com/tcdude/py-klondike-solver/archive/{version}.zip'
+    site_packages_name = 'pyksolve'
+
+    depends = ['python3', 'setuptools']
+
+    def build_compiled_components(self, arch):
+        self.setup_extra_args = ['-j', str(cpu_count())]
+        super(PyksolveRecipe, self).build_compiled_components(arch)
+        self.setup_extra_args = []
+
+    def rebuild_compiled_components(self, arch, env):
+        self.setup_extra_args = ['-j', str(cpu_count())]
+        super(PyksolveRecipe, self).rebuild_compiled_components(arch, env)
+        self.setup_extra_args = []
+
+recipe = PyksolveRecipe()

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,8 @@ def ext_modules():
                          annotate=False)
     return EXTENSIONS
 
-# If the submodule hasn't been cloned recursively, download it.
+
+# Check if the submodule is present, download if not.
 if not os.path.exists('ext/klondike-solver/Solitaire.cpp'):
     import io, shutil, urllib.request, zipfile
     uri = 'https://github.com/ShootMe/Klondike-Solver/archive/master.zip'
@@ -88,10 +89,12 @@ if not os.path.exists('ext/klondike-solver/Solitaire.cpp'):
     zipf = zipfile.ZipFile(buf)
     os.makedirs('tmp')
     zipf.extractall('tmp')
-    os.makedirs('ext/klondike-solver')
+    if not os.path.exists('ext/klondike-solver'):
+        os.makedirs('ext/klondike-solver')
     for pth in glob.glob('tmp/Klondike-Solver-master/*', recursive=True):
         shutil.move(pth, 'ext/klondike-solver')
     shutil.rmtree('tmp')
+
 
 setup(
     name='pyksolve',

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ EXTENSIONS = [
         extra_compile_args=EXTRA_COMPILE_ARGS,
         extra_link_args=EXTRA_LINK_ARGS,
         language='c++',
-        libraries=['c++_shared'] if platform.machine() != 'x86_64' else []
+        libraries=['c++_shared']
     )
     for i in glob.glob('src/pyksolve/**/*' + EXT, recursive=True)
 ]

--- a/setup.py
+++ b/setup.py
@@ -87,13 +87,14 @@ if not os.path.exists('ext/klondike-solver/Solitaire.cpp'):
     req = urllib.request.urlopen(uri)
     buf = io.BytesIO(req.read())
     zipf = zipfile.ZipFile(buf)
-    os.makedirs('tmp')
+    if not os.path.exists('tmp'):
+        os.makedirs('tmp')
     zipf.extractall('tmp')
     if not os.path.exists('ext/klondike-solver'):
         os.makedirs('ext/klondike-solver')
     for pth in glob.glob('tmp/Klondike-Solver-master/*', recursive=True):
         shutil.move(pth, 'ext/klondike-solver')
-    shutil.rmtree('tmp')
+    shutil.rmtree('tmp/Klondike-Solver-master')
 
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -59,7 +59,8 @@ EXTENSIONS = [
         include_dirs=['ext/klondike-solver'],
         extra_compile_args=EXTRA_COMPILE_ARGS,
         extra_link_args=EXTRA_LINK_ARGS,
-        language='c++'
+        language='c++',
+        libraries=['c++_shared'] if platform.machine() != 'x86_64' else []
     )
     for i in glob.glob('src/pyksolve/**/*' + EXT, recursive=True)
 ]


### PR DESCRIPTION
Add logic to `setup.py` to enable builds through `python-for-android`. 
 * Adds additional library to the Extension
 * Downloads the submodule if not already present
 * Add a `python-for-android` build recipe